### PR TITLE
Handle error response for odoo.connect()

### DIFF
--- a/lib/odoo.js
+++ b/lib/odoo.js
@@ -37,12 +37,26 @@ class Odoo {
 			Accept: 'application/json'
 		};
 
+		const createError = err => {
+			const error = new Error(err.message);
+			error.code = err.code;
+			error.data = err.data;
+			return error;
+		};
+
 		return got.post(`${config.host}:${config.port}/web/session/authenticate`, {json: true, headers, body})
-			.then(res => new OdooClient(res.body.result, {
-				host: config.host,
-				port: config.port,
-				sid: res.headers['set-cookie'][0].split(';')[0]
-			}));
+			.then(res => {
+				if (res.body.error) {
+					// HTTP Status is 200 / OK!
+					throw createError(res.body.error);
+				}
+
+				return new OdooClient(res.body.result, {
+					host: config.host,
+					port: config.port,
+					sid: res.headers['set-cookie'][0].split(';')[0]
+				});
+			});
 	}
 }
 

--- a/test/fixtures/setup.js
+++ b/test/fixtures/setup.js
@@ -55,5 +55,36 @@ module.exports = test => {
 					]
 				}
 			});
+
+		const failBody = {
+			params: {
+				db: 'fail',
+				login: 'fail',
+				password: 'fail'
+			}
+		};
+
+		gotPost
+			.withArgs('foobar.com:80/web/session/authenticate', {
+				json: true,
+				headers,
+				body: JSON.stringify(failBody)
+			})
+			.resolves({
+				body: {
+					jsonrpc: '2.0',
+					id: null,
+					error: {
+						message: 'Odoo Server Error',
+						code: 200,
+						data: {
+							debug: 'Traceback ...'
+						}
+					}
+				},
+				headers: {
+					'content-type': 'application/json'
+				}
+			});
 	});
 };

--- a/test/test.js
+++ b/test/test.js
@@ -33,3 +33,16 @@ test('connect', async t => {
 		sid: 'session_id=2ad18d37785fab31c8e9e3cb8c21f8917f48b63b'
 	});
 });
+
+test('connect failure', async t => {
+	const odoo = new Odoo({host: 'foobar.com'});
+	const error = await t.throws(odoo.connect({
+		database: 'fail',
+		username: 'fail',
+		password: 'fail'
+	}), Error, 'Odoo Server Error');
+	t.is(error.code, 200);
+	t.deepEqual(error.data, {
+		debug: 'Traceback ...'
+	});
+});


### PR DESCRIPTION
When the underlying request would return an error response (for some reason HTTP status 200 is used... 😞), the `connect()` promise was still being resolved to a `Odoo` object, instead of being rejected.