### PR TITLE
Support session id retrieval from headers if retrieval from body fails

### DIFF
--- a/lib/odoo.js
+++ b/lib/odoo.js
@@ -57,11 +57,14 @@ class Odoo {
 					protocol: config.protocol,
 					host: config.host,
 					port: config.port,
-					sid: `session_id=${res.body.result.session_id}`
+					sid: res.body.result.session_id ? `session_id=${res.body.result.session_id}` : this.getSessionId(res.headers['set-cookie'])
 				});
 			});
+	}
+
+	getSessionId(headers){
+		return headers.find(x=>x.indexOf('session_id') > -1);
 	}
 }
 
 module.exports = Odoo;
-


### PR DESCRIPTION
In Odoo 14  session id appears not to be stored in res.body. I made a fix to retrieve it from headers in case it's missing in the body.